### PR TITLE
Don't use unstable features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ num = "*"
 libc = "*"
 sdl2 = "^0.4.0"
 sdl2-sys = "^0.4.0"
-c_vec = "1.1.*"
+c_vec = "1.0.*"
 
 [[bin]]
 name = "demo"

--- a/src/sdl2_gfx/imagefilter.rs
+++ b/src/sdl2_gfx/imagefilter.rs
@@ -1,7 +1,6 @@
 //! MMX image filters
 
 use std::mem;
-use std::ptr::Unique;
 use libc;
 use libc::{size_t, c_void, c_uint, c_int};
 use sdl2::SdlResult;
@@ -106,7 +105,7 @@ pub fn mmx_on() {
 fn cvec_with_size(sz: usize) -> CVec<u8> {
     unsafe {
         let p = libc::malloc(sz as size_t) as *mut u8;
-        CVec::new_with_dtor(Unique::new(p), sz, move |p| {
+        CVec::new_with_dtor(p, sz, move |p| {
             libc::free(p as *mut c_void)
         })
     }

--- a/src/sdl2_gfx/lib.rs
+++ b/src/sdl2_gfx/lib.rs
@@ -2,8 +2,6 @@
 A binding for SDL2_gfx.
  */
 
-#![feature(unique)]
-
 extern crate libc;
 extern crate num;
 extern crate sdl2;


### PR DESCRIPTION
When looking at a comparison between c_vec v1.1 and master (v1.0.12)
the only difference is v1.1 is using unstable features.

I'm not sure why the unstable, older version has the highest version number.

https://github.com/GuillaumeGomez/c_vec-rs/compare/1.1...master
